### PR TITLE
Fix spawn overlap and add game over check

### DIFF
--- a/block-game.html
+++ b/block-game.html
@@ -249,6 +249,15 @@
 
             if (!currentPiece) {
                 currentPiece = new Piece();
+                // Game over is triggered here if the new piece cannot be placed
+                // at its spawn position. canMove(0, 0) checks for collisions with
+                // existing blocks. If spawning overlaps, we stop the loop and
+                // reveal the game over screen.
+                if (!currentPiece.canMove(0, 0)) {
+                    gameRunning = false;
+                    showGameOver();
+                    return;
+                }
             }
 
             if (!currentPiece.move(0, 1)) {


### PR DESCRIPTION
## Summary
- prevent pieces from spawning over existing blocks by checking before first move
- explain the new game over trigger in comments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842676316b4832098c919f13d8d751b